### PR TITLE
Añadir soporte para Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:xenial
 
-LABEL maintainer "Jakub Vanak"
+LABEL maintainer "Jakub Vanak (https://github.com/Koubek)"
 
 COPY data /root/alastria-node/data
 RUN chmod -R u+x /root/alastria-node/data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:xenial
+
+LABEL maintainer "Jakub Vanak"
+
+COPY data /root/alastria-node/data
+RUN chmod -R u+x /root/alastria-node/data
+
+COPY scripts /root/alastria-node/scripts
+RUN chmod -R u+x /root/alastria-node/scripts
+
+WORKDIR /root/alastria-node/scripts
+
+RUN sed -i -e 's/\r$//' init.sh && sed -i -e 's/\r$//' bootstrap.sh && sed -i -e 's/\r$//' start.sh
+
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -q -y curl \
+  libcurl3 unzip wget git make gcc libsodium-dev build-essential libdb-dev zlib1g-dev libtinfo-dev sysvbanner wrk psmisc
+
+WORKDIR /root/alastria-node/scripts
+RUN ./bootstrap.sh
+
+EXPOSE 9000 21000 21000/udp 22000 41000
+
+# CMD ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN sed -i -e 's/\r$//' init.sh && sed -i -e 's/\r$//' bootstrap.sh && sed -i -e
 RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -q -y curl \
-  libcurl3 unzip wget git make gcc libsodium-dev build-essential libdb-dev zlib1g-dev libtinfo-dev sysvbanner wrk psmisc
+  libcurl3 unzip wget git make gcc libsodium-dev build-essential libdb-dev zlib1g-dev libtinfo-dev sysvbanner wrk psmisc sudo
 
 WORKDIR /root/alastria-node/scripts
 RUN ./bootstrap.sh

--- a/README.md
+++ b/README.md
@@ -82,3 +82,22 @@ A la hora de realizar transacciones en la red de Alastria es necesario realizar 
 Una vez que se levantado el nodo, es necesaria la realización de una transferencia de fondos de la cuenta principal a la cuenta que acaba de ser generada al iniciarse el nodo.
 
 Con el fin de realizar este procedimiento se debe indicar al administrador del primer nodo de la red, poseedor de la cuenta principal, la cuenta que se ha generado al levantar el nodo. Tras esto, el administrador deberá asignar a la cuenta del nodo la cantidad que se haya acordado.
+
+
+## Build/Run with Docker
+
+Para poder ejecutar **Quorum** y **Constellation** con [Docker](https://www.docker.com/) se añade el fichero `Dockerfile`.
+
+Primer paso sería crear la imagen en base del fichero `Dockerfile` con este commando:
+```
+docker build -t alastria .
+```
+
+Al tener la imagen preparada se puede ejecutar (ahora en forma experimental e interactiva solo):
+```
+docker run -it --rm --name alastria alastria bash
+```
+
+Y ahora, dentro del shell del contenedor se pueden ejecutar los scripts `init.sh` y `start.sh`.
+
+Posiblemente en futuro habrá la imagen disponible para descargar en [docker hub](https://hub.docker.com/) y por eso no hará falta realizar la construcción de la imagen (el primer paso).

--- a/README.md
+++ b/README.md
@@ -86,9 +86,17 @@ Con el fin de realizar este procedimiento se debe indicar al administrador del p
 
 ## Build/Run with Docker
 
-Para poder ejecutar **Quorum** y **Constellation** con [Docker](https://www.docker.com/) se añade el fichero `Dockerfile`.
+**NOTA**
+Ejecución con Docker es muy experimental y se requiere ejecutar el contenedor en modo interactivo y desde allí ejecutar los scripts `init.sh` y `start.sh`.
 
-Primer paso sería crear la imagen en base del fichero `Dockerfile` con este commando:
+
+Existen dos posibilidades cómo ejecutar **Quorum** y **Constellation** con [Docker](https://www.docker.com/):
+- Primera posibilidad es la más fácil y depende de una imagen de Docker disponible en [Docker Hub](hub.docker.com). En este caso lo único que se requiere es ejecutar el siguiente comando:
+```
+docker run -it --rm --name alastria koubek/alastria-node bash
+```
+
+- La segundo opción supone de que la imagen se quiere construir por el usuario mismo y para ello sirve el fichero `Dockerfile`. Para crear la imagen propia hay que ejecutar el siguiente este commando desde la carpeta dónde se encuentra el mismo fichero `Dockerfile`:
 ```
 docker build -t alastria .
 ```
@@ -97,7 +105,3 @@ Al tener la imagen preparada se puede ejecutar (ahora en forma experimental e in
 ```
 docker run -it --rm --name alastria alastria bash
 ```
-
-Y ahora, dentro del shell del contenedor se pueden ejecutar los scripts `init.sh` y `start.sh`.
-
-Posiblemente en futuro habrá la imagen disponible para descargar en [docker hub](https://hub.docker.com/) y por eso no hará falta realizar la construcción de la imagen (el primer paso).

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Ejecución con Docker es muy experimental y se requiere ejecutar el contenedor e
 Existen dos posibilidades cómo ejecutar **Quorum** y **Constellation** con [Docker](https://www.docker.com/):
 - Primera posibilidad es la más fácil y depende de una imagen de Docker disponible en [Docker Hub](hub.docker.com). En este caso lo único que se requiere es ejecutar el siguiente comando:
 ```
-docker run -it --rm --name alastria koubek/alastria-node bash
+docker run -it --rm --name alastria -p 9000:9000 -p 21000:21000 -p 22000:22000 -p 41000:41000 koubek/alastria-node bash
 ```
 
 - La segundo opción supone de que la imagen se quiere construir por el usuario mismo y para ello sirve el fichero `Dockerfile`. Para crear la imagen propia hay que ejecutar el siguiente este commando desde la carpeta dónde se encuentra el mismo fichero `Dockerfile`:
@@ -103,5 +103,5 @@ docker build -t alastria .
 
 Al tener la imagen preparada se puede ejecutar (ahora en forma experimental e interactiva solo):
 ```
-docker run -it --rm --name alastria alastria bash
+docker run -it --rm --name alastria -p 9000:9000 -p 21000:21000 -p 22000:22000 -p 41000:41000 alastria bash
 ```

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -5,34 +5,34 @@ set -e
 GOREL="go1.7.3.linux-amd64.tar.gz"
 PATH="$PATH:/usr/local/go/bin"
 
-rm -Rf /usr/local/go
+sudo rm -Rf /usr/local/go
 
-apt-get update && apt-get install -y
+sudo apt-get update && sudo apt-get install -y
 
 #INSTALACION DE LIBRERIAS
-apt-get install -y software-properties-common unzip wget git make gcc libsodium-dev build-essential libdb-dev zlib1g-dev libtinfo-dev sysvbanner wrk psmisc
+sudo apt-get install -y software-properties-common unzip wget git make gcc libsodium-dev build-essential libdb-dev zlib1g-dev libtinfo-dev sysvbanner wrk psmisc
 
 #INSTALACION ETHEREUM
-add-apt-repository -y ppa:ethereum/ethereum && apt-get update && apt-get install -y solc
+sudo add-apt-repository -y ppa:ethereum/ethereum && sudo apt-get update && sudo apt-get install -y solc
 
 #INSTALACION CONSTELLATION 0.1.0
 wget -q https://github.com/jpmorganchase/constellation/releases/download/v0.1.0/constellation-0.1.0-ubuntu1604.tar.xz 
 unxz constellation-0.1.0-ubuntu1604.tar.xz 
 tar -xf constellation-0.1.0-ubuntu1604.tar
-cp constellation-0.1.0-ubuntu1604/constellation-node /usr/local/bin && chmod 0755 /usr/local/bin/constellation-node
-rm -rf constellation-0.1.0-ubuntu1604.tar.xz constellation-0.1.0-ubuntu1604.tar constellation-0.1.0-ubuntu1604
+sudo cp constellation-0.1.0-ubuntu1604/constellation-node /usr/local/bin && sudo chmod 0755 /usr/local/bin/constellation-node
+sudo rm -rf constellation-0.1.0-ubuntu1604.tar.xz constellation-0.1.0-ubuntu1604.tar constellation-0.1.0-ubuntu1604
 
 #INSTALACION DE GO
 wget -q "https://storage.googleapis.com/golang/${GOREL}"
 tar -xvzf "${GOREL}"
 mv go /usr/local/go
-rm "${GOREL}"
+sudo rm "${GOREL}"
 
 #INSTALACION DE QUORUM
 git clone https://github.com/jpmorganchase/quorum.git
 cd quorum && git checkout tags/v1.1.0 && make all &&  cp build/bin/geth /usr/local/bin && cp build/bin/bootnode /usr/local/bin
 
 cd ..
-rm -rf constellation-0.1.0-ubuntu1604.tar.xz constellation-0.1.0-ubuntu1604.tar constellation-0.1.0-ubuntu1604 quorum
+sudo rm -rf constellation-0.1.0-ubuntu1604.tar.xz constellation-0.1.0-ubuntu1604.tar constellation-0.1.0-ubuntu1604 quorum
 
 set +e

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -5,34 +5,34 @@ set -e
 GOREL="go1.7.3.linux-amd64.tar.gz"
 PATH="$PATH:/usr/local/go/bin"
 
-sudo rm -Rf /usr/local/go
+rm -Rf /usr/local/go
 
-sudo apt-get update && sudo apt-get install -y
+apt-get update && apt-get install -y
 
 #INSTALACION DE LIBRERIAS
-sudo apt-get install -y software-properties-common unzip wget git make gcc libsodium-dev build-essential libdb-dev zlib1g-dev libtinfo-dev sysvbanner wrk psmisc
+apt-get install -y software-properties-common unzip wget git make gcc libsodium-dev build-essential libdb-dev zlib1g-dev libtinfo-dev sysvbanner wrk psmisc
 
 #INSTALACION ETHEREUM
-sudo add-apt-repository -y ppa:ethereum/ethereum && sudo apt-get update && sudo apt-get install -y solc
+add-apt-repository -y ppa:ethereum/ethereum && apt-get update && apt-get install -y solc
 
 #INSTALACION CONSTELLATION 0.1.0
 wget -q https://github.com/jpmorganchase/constellation/releases/download/v0.1.0/constellation-0.1.0-ubuntu1604.tar.xz 
 unxz constellation-0.1.0-ubuntu1604.tar.xz 
 tar -xf constellation-0.1.0-ubuntu1604.tar
-sudo cp constellation-0.1.0-ubuntu1604/constellation-node /usr/local/bin && sudo chmod 0755 /usr/local/bin/constellation-node
-sudo rm -rf constellation-0.1.0-ubuntu1604.tar.xz constellation-0.1.0-ubuntu1604.tar constellation-0.1.0-ubuntu1604
+cp constellation-0.1.0-ubuntu1604/constellation-node /usr/local/bin && chmod 0755 /usr/local/bin/constellation-node
+rm -rf constellation-0.1.0-ubuntu1604.tar.xz constellation-0.1.0-ubuntu1604.tar constellation-0.1.0-ubuntu1604
 
 #INSTALACION DE GO
 wget -q "https://storage.googleapis.com/golang/${GOREL}"
 tar -xvzf "${GOREL}"
 mv go /usr/local/go
-sudo rm "${GOREL}"
+rm "${GOREL}"
 
 #INSTALACION DE QUORUM
 git clone https://github.com/jpmorganchase/quorum.git
 cd quorum && git checkout tags/v1.1.0 && make all &&  cp build/bin/geth /usr/local/bin && cp build/bin/bootnode /usr/local/bin
 
 cd ..
-sudo rm -rf constellation-0.1.0-ubuntu1604.tar.xz constellation-0.1.0-ubuntu1604.tar constellation-0.1.0-ubuntu1604 quorum
+rm -rf constellation-0.1.0-ubuntu1604.tar.xz constellation-0.1.0-ubuntu1604.tar constellation-0.1.0-ubuntu1604 quorum
 
 set +e


### PR DESCRIPTION
Añadir soporte para Docker.
Crear la imagen Docker automáticamente con CI pipeline + colocarla a Docker Hub.