### PR TITLE
Added --rpccorsdomain option for geth from environment or command line

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -8,7 +8,7 @@ kill_geth() {
 }
 trap kill_geth SIGTERM
 
-MESSAGE='Usage: start.sh <--clean> <--no-monitor> <--watch> <--local-rpc> <--logrotate>'
+MESSAGE='Usage: start.sh <--clean> <--no-monitor> <--watch> <--local-rpc> <--logrotate> <--cors-domains <value>>'
 
 MONITOR=1
 WATCH=0
@@ -38,6 +38,10 @@ do
     ;;
     -r|-R|--logrotate)
     LOGROTATE=1
+    ;;
+    -d|-D|--cors-domains)
+    QUORUM_CORS_DOMAINS=$2;
+    shift;
     ;;
     -h|-H|--help)
     echo $MESSAGE
@@ -70,10 +74,12 @@ NETID=83584648538
 mapfile -t IDENTITY <~/alastria/data/IDENTITY
 mapfile -t NODE_TYPE <~/alastria/data/NODE_TYPE
 
+[ ! -z "$QUORUM_CORS_DOMAINS" ] && QUORUM_CORS_DOMAINS="--rpccorsdomain \"$QUORUM_CORS_DOMAINS\""
+
 if [ "$NODE_TYPE" == "bootnode" ]; then
    GLOBAL_ARGS="--networkid $NETID --identity $IDENTITY --permissioned --port 21000 --ethstats $IDENTITY:bb98a0b6442386d0cdf8a31b267892c1@netstats.telsius.alastria.io:80 --targetgaslimit 18446744073709551615 --syncmode fast --nodiscover "
  else
-   GLOBAL_ARGS="--networkid $NETID --identity $IDENTITY --permissioned --rpc --rpcaddr $RPCADDR --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul --rpcport 22000 --port 21000 --istanbul.requesttimeout 10000  --ethstats $IDENTITY:bb98a0b6442386d0cdf8a31b267892c1@netstats.telsius.alastria.io:80 --verbosity 3 --vmdebug --emitcheckpoints --targetgaslimit 18446744073709551615 --syncmode full --gcmode $GCMODE --vmodule consensus/istanbul/core/core.go=5 --nodiscover "
+   GLOBAL_ARGS="--networkid $NETID --identity $IDENTITY --permissioned --rpc --rpcaddr $RPCADDR $QUORUM_CORS_DOMAINS --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul --rpcport 22000 --port 21000 --istanbul.requesttimeout 10000  --ethstats $IDENTITY:bb98a0b6442386d0cdf8a31b267892c1@netstats.telsius.alastria.io:80 --verbosity 3 --vmdebug --emitcheckpoints --targetgaslimit 18446744073709551615 --syncmode full --gcmode $GCMODE --vmodule consensus/istanbul/core/core.go=5 --nodiscover "
 fi
 
 _TIME="_$(date +%Y%m%d%H%M%S)"


### PR DESCRIPTION
These changes to scripts/start.sh permit to use -d|-D|--cors-domais option from command line, or QUORUM_CORS_DOMAINS environment variable to set --rpccorsdomain option of geth.

Please, evaluate if this could help.

Best regards