### PR TITLE
Solve problem with IP auto-discover and typo in general/entrypoint

### DIFF
--- a/docker/bootnode/Dockerfile
+++ b/docker/bootnode/Dockerfile
@@ -31,15 +31,19 @@ RUN \
         curl \
         dnsutils \
         nano \
-    && cd \
-    && git clone -b $ALASTRIA_BRANCH https://github.com/tlmat-unican/alastria-node \
     && apt-get autoremove \
-    && apt-get clean
+    && apt-get clean \
+    && cd
+
+# Prevent Docker from caching git clone
+ADD https://api.github.com/repos/tlmat-unican/alastria-node/git/refs/heads/$ALASTRIA_BRANCH version.json
+RUN git clone -b $ALASTRIA_BRANCH https://github.com/tlmat-unican/alastria-node
 
 VOLUME /root/alastria
 EXPOSE 21000 21000/udp 8443
 
 COPY entrypoint.sh /usr/bin/
+
 WORKDIR /root/alastria-node
 ENTRYPOINT ["entrypoint.sh"]
 CMD

--- a/docker/bootnode/Dockerfile
+++ b/docker/bootnode/Dockerfile
@@ -19,6 +19,7 @@ FROM ubuntu:16.04
 
 ARG DOCKER_VERSION=latest
 ARG ALASTRIA_BRANCH=testnet2
+ARG GITHUB_USER=tlmat-unican
 
 ENV \
     DOCKER_VERSION=$DOCKER_VERSION
@@ -36,8 +37,8 @@ RUN \
     && cd
 
 # Prevent Docker from caching git clone
-ADD https://api.github.com/repos/tlmat-unican/alastria-node/git/refs/heads/$ALASTRIA_BRANCH version.json
-RUN git clone -b $ALASTRIA_BRANCH https://github.com/tlmat-unican/alastria-node
+ADD https://api.github.com/repos/$GITHUB_USER/alastria-node/git/refs/heads/$ALASTRIA_BRANCH version.json
+RUN git clone -b $ALASTRIA_BRANCH https://github.com/$GITHUB_USER/alastria-node
 
 VOLUME /root/alastria
 EXPOSE 21000 21000/udp 8443

--- a/docker/bootnode/Dockerfile
+++ b/docker/bootnode/Dockerfile
@@ -19,7 +19,7 @@ FROM ubuntu:16.04
 
 ARG DOCKER_VERSION=latest
 ARG ALASTRIA_BRANCH=testnet2
-ARG GITHUB_USER=tlmat-unican
+ARG GITHUB_USER=alastria
 
 ENV \
     DOCKER_VERSION=$DOCKER_VERSION
@@ -33,12 +33,13 @@ RUN \
         dnsutils \
         nano \
     && apt-get autoremove \
-    && apt-get clean \
-    && cd
+    && apt-get clean
 
 # Prevent Docker from caching git clone
 ADD https://api.github.com/repos/$GITHUB_USER/alastria-node/git/refs/heads/$ALASTRIA_BRANCH version.json
-RUN git clone -b $ALASTRIA_BRANCH https://github.com/$GITHUB_USER/alastria-node
+RUN \
+    cd \
+    && git clone -b $ALASTRIA_BRANCH https://github.com/$GITHUB_USER/alastria-node
 
 VOLUME /root/alastria
 EXPOSE 21000 21000/udp 8443

--- a/docker/bootnode/Dockerfile
+++ b/docker/bootnode/Dockerfile
@@ -32,7 +32,7 @@ RUN \
         dnsutils \
         nano \
     && cd \
-    && git clone -b $ALASTRIA_BRANCH https://github.com/alastria/alastria-node \
+    && git clone -b $ALASTRIA_BRANCH https://github.com/tlmat-unican/alastria-node \
     && apt-get autoremove \
     && apt-get clean
 

--- a/docker/general/Dockerfile
+++ b/docker/general/Dockerfile
@@ -36,16 +36,20 @@ RUN \
         nano \
     && rm -Rf /etc/nginx/sites-enabled/default \
     && rm -Rf /etc/nginx/sites-available/default \
-    && cd \
-    && git clone -b $ALASTRIA_BRANCH https://github.com/tlmat-unican/alastria-node \
     && apt-get autoremove \
-    && apt-get clean
+    && apt-get clean \
+    && cd
+
+# Prevent Docker from caching git clone
+ADD https://api.github.com/repos/tlmat-unican/alastria-node/git/refs/heads/$ALASTRIA_BRANCH version.json
+RUN git clone -b $ALASTRIA_BRANCH https://github.com/tlmat-unican/alastria-node 
 
 VOLUME /root/alastria
 VOLUME /etc/nginx/conf.d
 EXPOSE 9000 21000 21000/udp 22000 8443 80 443
 
 COPY entrypoint.sh /usr/bin/
+
 WORKDIR /root/alastria-node
 ENTRYPOINT ["entrypoint.sh"]
 CMD

--- a/docker/general/Dockerfile
+++ b/docker/general/Dockerfile
@@ -19,7 +19,7 @@ FROM ubuntu:16.04
 
 ARG DOCKER_VERSION=latest
 ARG ALASTRIA_BRANCH=testnet2
-ARG GITHUB_USER=tlmat-unican
+ARG GITHUB_USER=alastria
 
 ENV \
     DOCKER_VERSION=$DOCKER_VERSION
@@ -38,12 +38,13 @@ RUN \
     && rm -Rf /etc/nginx/sites-enabled/default \
     && rm -Rf /etc/nginx/sites-available/default \
     && apt-get autoremove \
-    && apt-get clean \
-    && cd
+    && apt-get clean
 
 # Prevent Docker from caching git clone
 ADD https://api.github.com/repos/$GITHUB_USER/alastria-node/git/refs/heads/$ALASTRIA_BRANCH version.json
-RUN git clone -b $ALASTRIA_BRANCH https://github.com/$GITHUB_USER/alastria-node 
+RUN \
+    cd \
+    && git clone -b $ALASTRIA_BRANCH https://github.com/$GITHUB_USER/alastria-node 
 
 VOLUME /root/alastria
 VOLUME /etc/nginx/conf.d

--- a/docker/general/Dockerfile
+++ b/docker/general/Dockerfile
@@ -19,6 +19,7 @@ FROM ubuntu:16.04
 
 ARG DOCKER_VERSION=latest
 ARG ALASTRIA_BRANCH=testnet2
+ARG GITHUB_USER=tlmat-unican
 
 ENV \
     DOCKER_VERSION=$DOCKER_VERSION
@@ -41,8 +42,8 @@ RUN \
     && cd
 
 # Prevent Docker from caching git clone
-ADD https://api.github.com/repos/tlmat-unican/alastria-node/git/refs/heads/$ALASTRIA_BRANCH version.json
-RUN git clone -b $ALASTRIA_BRANCH https://github.com/tlmat-unican/alastria-node 
+ADD https://api.github.com/repos/$GITHUB_USER/alastria-node/git/refs/heads/$ALASTRIA_BRANCH version.json
+RUN git clone -b $ALASTRIA_BRANCH https://github.com/$GITHUB_USER/alastria-node 
 
 VOLUME /root/alastria
 VOLUME /etc/nginx/conf.d

--- a/docker/general/Dockerfile
+++ b/docker/general/Dockerfile
@@ -37,7 +37,7 @@ RUN \
     && rm -Rf /etc/nginx/sites-enabled/default \
     && rm -Rf /etc/nginx/sites-available/default \
     && cd \
-    && git clone -b $ALASTRIA_BRANCH https://github.com/alastria/alastria-node \
+    && git clone -b $ALASTRIA_BRANCH https://github.com/tlmat-unican/alastria-node \
     && apt-get autoremove \
     && apt-get clean
 

--- a/docker/general/entrypoint.sh
+++ b/docker/general/entrypoint.sh
@@ -11,6 +11,7 @@ git pull
 cd ./scripts
 sed -i 's/sudo//g' bootstrap.sh
 ./bootstrap.sh
+./monitor.sh build
 
 if [ ! -f ~/alastria/data/IDENTITY ]; then
     ./init.sh auto $NODE_TYPE $NODE_NAME
@@ -23,10 +24,9 @@ fi
 
 /etc/init.d/nginx start
 nginx -g "daemon off;"
-ARGS="--watch --local-rpc --no-monitor"
-if [ ! $MONITOR_ENABLED -eq 0 ]; then
-    ./monitor.sh build
-    ARGS="--watch --local-rpc"
+ARGS="--watch --local-rpc"
+if [ ! $MONITOR_ENABLED -eq 1 ]; then
+    ARGS="--watch --local-rpc --no-monitor"
 fi
 exec ./start.sh $ARGS &
 

--- a/docker/general/entrypoint.sh
+++ b/docker/general/entrypoint.sh
@@ -11,7 +11,6 @@ git pull
 cd ./scripts
 sed -i 's/sudo//g' bootstrap.sh
 ./bootstrap.sh
-./monitor.sh build
 
 if [ ! -f ~/alastria/data/IDENTITY ]; then
     ./init.sh auto $NODE_TYPE $NODE_NAME
@@ -24,9 +23,10 @@ fi
 
 /etc/init.d/nginx start
 nginx -g "daemon off;"
-ARGS="--watch --local-rpc"
-if [ ! $MONITOR_ENABLED -eq 1 ]; then
-    AGRS="--watch --local-rpc --no-monitor"
+ARGS="--watch --local-rpc --no-monitor"
+if [ ! $MONITOR_ENABLED -eq 0 ]; then
+    ./monitor.sh build
+    ARGS="--watch --local-rpc"
 fi
 exec ./start.sh $ARGS &
 

--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -19,7 +19,7 @@ FROM ubuntu:16.04
 
 ARG DOCKER_VERSION=latest
 ARG ALASTRIA_BRANCH=testnet2
-ARG GITHUB_USER=tlmat-unican
+ARG GITHUB_USER=alastria
 
 ENV \
     DOCKER_VERSION=$DOCKER_VERSION
@@ -38,12 +38,13 @@ RUN \
     && rm -Rf /etc/nginx/sites-enabled/default \
     && rm -Rf /etc/nginx/sites-available/default \
     && apt-get autoremove \
-    && apt-get clean \
-    && cd
+    && apt-get clean
 
 # Prevent Docker from caching git clone
 ADD https://api.github.com/repos/$GITHUB_USER/alastria-node/git/refs/heads/$ALASTRIA_BRANCH version.json
-RUN git clone -b $ALASTRIA_BRANCH https://github.com/$GITHUB_USER/alastria-node
+RUN \
+    cd \
+    && git clone -b $ALASTRIA_BRANCH https://github.com/$GITHUB_USER/alastria-node
 
 VOLUME /root/alastria
 VOLUME /etc/nginx/conf.d

--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -36,16 +36,20 @@ RUN \
         nano \
     && rm -Rf /etc/nginx/sites-enabled/default \
     && rm -Rf /etc/nginx/sites-available/default \
-    && cd \
-    && git clone -b $ALASTRIA_BRANCH https://github.com/tlmat-unican/alastria-node \
     && apt-get autoremove \
-    && apt-get clean
+    && apt-get clean \
+    && cd
+
+# Prevent Docker from caching git clone
+ADD https://api.github.com/repos/tlmat-unican/alastria-node/git/refs/heads/$ALASTRIA_BRANCH version.json
+RUN git clone -b $ALASTRIA_BRANCH https://github.com/tlmat-unican/alastria-node
 
 VOLUME /root/alastria
 VOLUME /etc/nginx/conf.d
 EXPOSE 9000 21000 21000/udp 22000 8443 80 443
 
 COPY entrypoint.sh /usr/bin/
+
 WORKDIR /root/alastria-node
 ENTRYPOINT ["entrypoint.sh"]
 CMD

--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -37,7 +37,7 @@ RUN \
     && rm -Rf /etc/nginx/sites-enabled/default \
     && rm -Rf /etc/nginx/sites-available/default \
     && cd \
-    && git clone -b $ALASTRIA_BRANCH https://github.com/alastria/alastria-node \
+    && git clone -b $ALASTRIA_BRANCH https://github.com/tlmat-unican/alastria-node \
     && apt-get autoremove \
     && apt-get clean
 

--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -19,6 +19,7 @@ FROM ubuntu:16.04
 
 ARG DOCKER_VERSION=latest
 ARG ALASTRIA_BRANCH=testnet2
+ARG GITHUB_USER=tlmat-unican
 
 ENV \
     DOCKER_VERSION=$DOCKER_VERSION
@@ -41,8 +42,8 @@ RUN \
     && cd
 
 # Prevent Docker from caching git clone
-ADD https://api.github.com/repos/tlmat-unican/alastria-node/git/refs/heads/$ALASTRIA_BRANCH version.json
-RUN git clone -b $ALASTRIA_BRANCH https://github.com/tlmat-unican/alastria-node
+ADD https://api.github.com/repos/$GITHUB_USER/alastria-node/git/refs/heads/$ALASTRIA_BRANCH version.json
+RUN git clone -b $ALASTRIA_BRANCH https://github.com/$GITHUB_USER/alastria-node
 
 VOLUME /root/alastria
 VOLUME /etc/nginx/conf.d

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -11,7 +11,7 @@ if ( [ $# -ne 3 ] ); then
     exit
 fi
 
-VALIDATOR0_HOST_IP="$(dig +short validator0.telsius.alastria.io @resolver1.opendns.com 2>/dev/null || curl -s --retry 2 icanhazip.com)"
+VALIDATOR0_HOST_IP="$(dig +short validator0.telsius.alastria.io @resolver1.opendns.com > /dev/null 2>&1 || curl -s --retry 2 icanhazip.com)"
 CURRENT_HOST_IP="$1"
 NODE_TYPE="$2"
 NODE_NAME="$3"
@@ -20,7 +20,7 @@ ACCOUNT_PASSWORD='Passw0rd'
 
 if ( [ "auto" == "$1" -o "backup" == "$1" ]); then
     echo "Autodiscovering public host IP ..."
-    CURRENT_HOST_IP="$(dig +short myip.opendns.com @resolver1.opendns.com 2>/dev/null || curl -s --retry 2 icanhazip.com)"
+    CURRENT_HOST_IP="$(dig +short myip.opendns.com @resolver1.opendns.com > /dev/null 2>&1 || curl -s --retry 2 icanhazip.com)"
     echo "Public host IP found: $CURRENT_HOST_IP"
 fi
 

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -16,7 +16,7 @@ mapfile -t NODE_TYPE <~/alastria/data/NODE_TYPE
 
 if ( [ "auto" == "$1" ]); then 
     echo "Autodiscovering public host IP ..."
-    CURRENT_HOST_IP="$(dig +short myip.opendns.com @resolver1.opendns.com 2>/dev/null || curl -s --retry 2 icanhazip.com)"
+    CURRENT_HOST_IP="$(dig +short myip.opendns.com @resolver1.opendns.com > /dev/null 2>&1 || curl -s --retry 2 icanhazip.com)"
     echo "Public host IP found: $CURRENT_HOST_IP"
 fi
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -47,8 +47,8 @@ do
   shift
 done
 
-VALIDATOR0_HOST_IP="$(dig +short validator0.telsius.alastria.io @resolver1.opendns.com 2>/dev/null || curl -s --retry 2 icanhazip.com)"
-CURRENT_HOST_IP="$(dig +short myip.opendns.com @resolver1.opendns.com 2>/dev/null || curl -s --retry 2 icanhazip.com)"
+VALIDATOR0_HOST_IP="$(dig +short validator0.telsius.alastria.io @resolver1.opendns.com > /dev/null 2>&1 || curl -s --retry 2 icanhazip.com)"
+CURRENT_HOST_IP="$(dig +short myip.opendns.com @resolver1.opendns.com > /dev/null 2>&1 || curl -s --retry 2 icanhazip.com)"
 CONSTELLATION_PORT=9000
 
 check_constellation_isStarted(){

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -147,11 +147,6 @@ else
     echo "Monitor disabled."
 fi
 
-if ([ $WATCH -gt 0 ])
-then
-  tail -100f ~/alastria/logs/quorum"${_TIME}".log
-fi
-
 if ([ $LOGROTATE -gt 0 ]) 
 then 
     RP=`readlink -m "$0"`
@@ -160,6 +155,13 @@ then
 else
    echo "Logrotate disabled."
 fi
-  
+
 set +u
 set +e
+
+if ([ $WATCH -gt 0 ])
+then
+  tail -100f ~/alastria/logs/quorum"${_TIME}".log
+fi
+  
+


### PR DESCRIPTION
Hola,
Los comandos asociados al descubrimiento de la IP pública de los nodos no redirigían bien la salida en caso de error al usar OpenDNS. En nuestro caso (que yo recuerde), la universidad tiene bloqueado el acceso a cualquier servidor DNS externo, por lo que la el uso de OpenDNS no es factible y de ahí que se active la segunda opción.

Adicionalmente, hemos incluido dos soluciones a dos errores "mínimos";
- En `docker/general/entrypoint.sh` nunca se podía deshabilitar la monitorización puesto que la variable que se generaba era nueva.
- En `scripts/start.sh` hemos modificado el orden de los if. Dado que el comando `tail` en la forma que estaba puesto es bloqueante, en principio se ejecutaría el `logrotate.sh`.

Por otro lado, en la historia podréis ver que habíamos modificado también el hecho de que no se compilara el monitor si no se necesitaba, pero hemos preferido restaurarlo para tener todo el sistema completo en la imagen de docker.

Por último, señalar que hemos incluido un comando en los Dockerfile para obligar a que siempre se descargue la última versión del repositorio `alastria-node` y no se haga cache de la versión inicialmente descargada al hacer la build. Esto es sensible para el caso de debug y testing en local. Y es por esto que hemos creado una variable que indique el usuario del que se tiene que descargar el repositorio.

Esperamos todo lo anterior sirva de ayuda.

Un saludo
UC Team