### PR TITLE
Add influx metrics and repo sync instructions for update.sh

### DIFF
--- a/INSTALAR_REGULAR.md
+++ b/INSTALAR_REGULAR.md
@@ -337,6 +337,32 @@ Si algún miembro del APCT solicita que se actualicen manualmente los ficheros d
     [*] Restarting node
     Relinking permissioning file
     [*] Starting quorum node
+    
+    
+Si sale el siguiente error en update.sh
+
+    error: Your local changes to the following files would be overwritten by merge:
+            data/constellation-nodes.json
+            data/regular-nodes.json
+
+es que el repositorio local no coincide con el punto en el que estaba al hacer la instalación, y se debe forzar la sincronización con la rama
+
+    $ cd ~/alastria-node/
+    $ git fetch --all
+    $ git reset --hard origin/testnet2
+
+Recién cuando el comando
+    
+    $ git status
+    
+arroje
+    
+    On branch testnet2
+    Your branch is up-to-date with 'origin/testnet2'.
+
+se puede reintentar el update.sh
+
+
 
 ### Probando el nodo regular
 

--- a/INSTALAR_VALIDATOR.md
+++ b/INSTALAR_VALIDATOR.md
@@ -353,12 +353,22 @@ Si sale el siguiente error en update.sh
             data/constellation-nodes.json
             data/regular-nodes.json
 
-es que la rama testnet2 ha avanzado, y se debe forzar la sincroniación con la misma
+es que el repositorio local no coincide con el punto en el que estaba al hacer la instalación, y se debe forzar la sincronización con la rama
 
-    $ cd ~/alastria-node/data
+    $ cd ~/alastria-node/
     $ git fetch --all
     $ git reset --hard origin/testnet2
 
+Recién cuando el comando
+    
+    $ git status
+    
+arroje
+    
+    On branch testnet2
+    Your branch is up-to-date with 'origin/testnet2'.
+
+Se puede reintentar el update.sh
 
 ### Integrando el nodo validador en el pool de validadores
 

--- a/INSTALAR_VALIDATOR.md
+++ b/INSTALAR_VALIDATOR.md
@@ -368,7 +368,7 @@ arroje
     On branch testnet2
     Your branch is up-to-date with 'origin/testnet2'.
 
-Se puede reintentar el update.sh
+se puede reintentar el update.sh
 
 ### Integrando el nodo validador en el pool de validadores
 

--- a/INSTALAR_VALIDATOR.md
+++ b/INSTALAR_VALIDATOR.md
@@ -332,6 +332,7 @@ Desde la consola del nodo:
     $ git checkout -- validator-nodes.json
     $ git checkout -- static-nodes.json
 
+
 Si algún miembro del APCT solicita que se actualicen manualmente los ficheros de permisionado y una vez asegurado que el repositorio local alastria-node está limpio de cambios, procedemos a actualizar los ficheros utilizando la siguiente secuencia de comandos:
 
     $ cd ~/alastria-node/scripts
@@ -344,6 +345,20 @@ Si algún miembro del APCT solicita que se actualicen manualmente los ficheros d
     [*] Restarting node
     Relinking permissioning file
     [*] Starting quorum node
+      
+    
+Si sale el siguiente error en update.sh
+
+    error: Your local changes to the following files would be overwritten by merge:
+            data/constellation-nodes.json
+            data/regular-nodes.json
+
+es que la rama testnet2 ha avanzado, y se debe forzar la sincroniación con la misma
+
+    $ cd ~/alastria-node/data
+    $ git fetch --all
+    $ git reset --hard origin/testnet2
+
 
 ### Integrando el nodo validador en el pool de validadores
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -70,10 +70,15 @@ NETID=83584648538
 mapfile -t IDENTITY <~/alastria/data/IDENTITY
 mapfile -t NODE_TYPE <~/alastria/data/NODE_TYPE
 
+#
+# options for metrics generation to InfluxDB server
+#
+INFLUX_METRICS=" --metrics --metrics.influxdb --metrics.influxdb.endpoint http://geth-metrics.planisys.net:8086 --metrics.influxdb.database alastria --metrics.influxdb.username alastriausr --metrics.influxdb.password ala0str1AX1 --metrics.influxdb.tags host=${IDENTITY}"
+
 if [ "$NODE_TYPE" == "bootnode" ]; then
-   GLOBAL_ARGS="--networkid $NETID --identity $IDENTITY --permissioned --port 21000 --ethstats $IDENTITY:bb98a0b6442386d0cdf8a31b267892c1@netstats.telsius.alastria.io:80 --targetgaslimit 8000000 --syncmode fast --nodiscover "
+   GLOBAL_ARGS="--networkid $NETID --identity $IDENTITY --permissioned --port 21000 --ethstats $IDENTITY:bb98a0b6442386d0cdf8a31b267892c1@netstats.telsius.alastria.io:80 --targetgaslimit 8000000 --syncmode fast --nodiscover ${INFLUX_METRICS}"
  else
-   GLOBAL_ARGS="--networkid $NETID --identity $IDENTITY --permissioned --rpc --rpcaddr $RPCADDR --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul --rpcport 22000 --port 21000 --istanbul.requesttimeout 10000  --ethstats $IDENTITY:bb98a0b6442386d0cdf8a31b267892c1@netstats.telsius.alastria.io:80 --verbosity 3 --vmdebug --emitcheckpoints --targetgaslimit 8000000 --syncmode full --gcmode $GCMODE --vmodule consensus/istanbul/core/core.go=5 --nodiscover "
+   GLOBAL_ARGS="--networkid $NETID --identity $IDENTITY --permissioned --rpc --rpcaddr $RPCADDR --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul --rpcport 22000 --port 21000 --istanbul.requesttimeout 10000  --ethstats $IDENTITY:bb98a0b6442386d0cdf8a31b267892c1@netstats.telsius.alastria.io:80 --verbosity 3 --vmdebug --emitcheckpoints --targetgaslimit 8000000 --syncmode full --gcmode $GCMODE --vmodule consensus/istanbul/core/core.go=5 --nodiscover ${INFLUX_METRICS}"
 fi
 
 _TIME="_$(date +%Y%m%d%H%M%S)"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -73,7 +73,7 @@ mapfile -t NODE_TYPE <~/alastria/data/NODE_TYPE
 #
 # options for metrics generation to InfluxDB server
 #
-INFLUX_METRICS=" --metrics --metrics.influxdb --metrics.influxdb.endpoint http://geth-metrics.planisys.net:8086 --metrics.influxdb.database alastria --metrics.influxdb.username alastriausr --metrics.influxdb.password ala0str1AX1 --metrics.influxdb.tags host=${IDENTITY}"
+INFLUX_METRICS=" --metrics --metrics.influxdb --metrics.influxdb.endpoint http://geth-metrics.planisys.net:8086 --metrics.influxdb.database alastria --metrics.influxdb.username alastriausr --metrics.influxdb.password ala0str1AX1 --metrics.influxdb.host.tag=${IDENTITY}"
 
 if [ "$NODE_TYPE" == "bootnode" ]; then
    GLOBAL_ARGS="--networkid $NETID --identity $IDENTITY --permissioned --port 21000 --ethstats $IDENTITY:bb98a0b6442386d0cdf8a31b267892c1@netstats.telsius.alastria.io:80 --targetgaslimit 8000000 --syncmode fast --nodiscover ${INFLUX_METRICS}"


### PR DESCRIPTION
Add metrics generation to influxdb server.
Add instructions to .md files , to force sync to testnet2 branch in case update.sh is not possible due to out-of-sync situation where local repository has changes with respect to alastria.