### PR TITLE
Review steps for Quorum 2.6.0 transition in non-docker nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ Restricted-Cone NAT has not been tested yet for p2p functionality.
 * [(English) Installation Guide](https://medium.com/babel-go2chain/setting-in-motion-a-bootnode-in-the-telsius-network-of-alastria-8e13915cb85d)
 * [(Spanish) Installation Guide](https://medium.com/babel-go2chain/c%C3%B3mo-poner-en-marcha-un-bootnode-en-la-red-telsius-de-alastria-18eacb20b224)
 
+
+## Upgrade to Quorum 2.6.0
+
+cd home/alastria-node/scripts
+./update.sh
+./stop.sh
+./bootstrap.sh reinstall
+ENABLE_CONSTELLATION=true ./start.sh
+
+
+
 ## Deployment of Smart Contracts on Alastria Network
 To know more about the use of Alastria Network, you can visit the Smart Contract Deployment Guides:
 * [Deploying to Alastria's network T (Quorum)](https://github.com/rogargon/copyrightly.io/blob/master/docs/NetworkT.md), created by Roberto Garcia, from Lleida University

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ You'll need to open the following ports in your firewall, inbound and outbound t
 The IP resulting out of the installation process (e.g. the IPv4 part of the enode) , must not be an RFC1918 IPv4 address
 
 10.0.0.0/8
+
 172.16.0.0/12
+
 192.168.0.0/16
 
 These IP addresses are non-routable and will result in your node being unreachable and unable to participate in the blockchain.
@@ -87,10 +89,16 @@ Restricted-Cone NAT has not been tested yet for p2p functionality.
 
 ## Upgrade to Quorum 2.6.0
 
+In case you installed directly on top of the operating system (without docker), please run this sequence and make sure you have port 6060 open for HTTP access of Prometheus remote server at IP address 185.180.8.244
+
 cd home/alastria-node/scripts
+
 ./update.sh
+
 ./stop.sh
+
 ./bootstrap.sh reinstall
+
 ENABLE_CONSTELLATION=true ./start.sh
 
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -11,12 +11,13 @@ function superuser {
 }
 
 function installgo {
-  GOREL="go1.9.5.linux-amd64.tar.gz"
+  #GOREL="go1.9.5.linux-amd64.tar.gz"
+  GOREL="go1.15.2.linux-amd64.tar.gz"
   if ( ! type "go" > /dev/null 2>&1 )
   then
     PATH="$PATH:/usr/local/go/bin"
     echo "Installing GO"    
-    wget "https://storage.googleapis.com/golang/$GOREL" -O /tmp/$GOREL
+    wget "https://golang.org/dl/$GOREL" -O /tmp/$GOREL
     pushd /tmp
     tar xvzf $GOREL
     superuser rm -rf /usr/local/go
@@ -99,9 +100,13 @@ function installquorum {
   then
     echo "Installing QUORUM"
     pushd /tmp
-    git clone https://github.com/alastria/quorum.git
+    #git clone https://github.com/alastria/quorum.git
+    git clone https://github.com/ConsenSys/quorum.git
     cd quorum
-    git checkout 775aa2f5a6a52d9d84c85d5ed73521a1ea5b15b3
+    #git checkout 775aa2f5a6a52d9d84c85d5ed73521a1ea5b15b3
+    #git checkout 30d4d724765a0c82a39db33088a66057896e7c83 #2.2.4
+    #git checkout c894c2d70eacf30740d03b53ed2fb39e42641295 #2.2.5
+    git checkout 9339be03f9119ee488b05cf087d103da7e68f053 #2.6.0
     make all
     superuser cp build/bin/geth /usr/local/bin
     superuser cp build/bin/bootnode /usr/local/bin


### PR DESCRIPTION
This PR should be reviewed by RedT Core Team.

The goal is to analyze the steps to upgrade to Quorum 2.6.0 / geth 1.9.7 for nodes that have quorum installed without docker.

There are no changes to genesis.json.

It adds Prometheus port 6060 to the list of ports that should be open for remote scraping.

Beware that geth now requires 5G resident RAM, and --cache 0 option adds stability to this memory footprint.
